### PR TITLE
Feat: AddMember to HouseholdProfile

### DIFF
--- a/Router.js
+++ b/Router.js
@@ -2,19 +2,20 @@ import React from "react";
 import { Router, Scene } from "react-native-router-flux";
 import { Start } from "./app/screens";
 import { Login, CreateUser, Main } from "./app/screens";
-import { ListPrivate, ListHousehold, HouseholdProfile } from "./app/components";
+import { ListPrivate, ListHousehold, HouseholdProfile, AddMember } from "./app/components";
 
 const Routes = () => {
   return (
     <Router>
       <Scene key="root">
-        <Scene key="home" title="Welcome To Peasy" component={Start} renderLeftButton={()=>(null)}></Scene>
+        <Scene key="home" title="Welcome To Peasy" component={Start} renderLeftButton={() => (null)}></Scene>
         <Scene key="login" title="Login" component={Login} ></Scene>
         <Scene key="signup" title="SignUp" component={CreateUser} ></Scene>
-        <Scene key="main" title="Main" component={Main} renderLeftButton={()=>(null)}></Scene>
+        <Scene key="main" title="Main" component={Main} renderLeftButton={() => (null)}></Scene>
         <Scene key="privateList" title="My Private List" component={ListPrivate}></Scene>
         <Scene key="householdList" title="My Household List" component={ListHousehold}></Scene>
         <Scene key="households" title="My Households" component={HouseholdProfile}></Scene>
+        <Scene key="addMember" title="Add a Member" component={AddMember}></Scene>
       </Scene>
     </Router>
   );

--- a/app/components/AddMember.js
+++ b/app/components/AddMember.js
@@ -1,18 +1,18 @@
 import React, { useEffect } from "react";
-import { Text, View, ScrollView, ImageBackground, Button, styles } from "react-native";
+import { Text, TextInput, View, ScrollView, ImageBackground, Button } from "react-native";
 import { globalStyles } from "../../styles/globalStyles";
 import { Formik } from "formik";
 
-export default function AddMember(props) {
+export default function AddMember() {
     return (
         <ImageBackground source={require("../../assets/peas.jpg")} style={globalStyles.background}>
             <View>
                 <Text style={globalStyles.button}> Invite a member to join your Household:  </Text>
             </View>
-            {/* <ScrollView>
+            <ScrollView>
                 <View style={{ justifyContent: "center" }}>
                     <Formik
-                        initialValues={{ email: "" }}
+                        initialValues={{ name: "", email: "" }}
                         validate={(values) => {
                             const errors = {};
                             if (!values.email) {
@@ -22,36 +22,37 @@ export default function AddMember(props) {
                             }
                             return errors;
                         }}
-                        //if statement to check that we dont have errors, else make thunk call
-                        onSubmit={(values) => {
-                            props.signin(values);
-                            saveUser(values);
-                            Actions.main();
-                        }}
-                    // call saveUser
+                    //if statement to check that we dont have errors, else make thunk call
+                    // onSubmit={(values) => {
+                    //     props.signin(values);
+
+                    //     Actions.main();
+                    // }}
                     >
                         {({ handleChange, handleBlur, handleSubmit, values, errors }) => (
-                            <View style={styles.signUpForm}>
-                                <View style={{ marginTop: 30 }}>
-                                    <Text>
-                                        Your household member's email <Text style={{ color: "red" }}> {errors.email ? errors.email : ""}</Text>
-                                    </Text>
-                                    <TextInput
-                                        style={styles.InputField}
-                                        onChangeText={handleChange("email")}
-                                        onBlur={handleBlur("email")}
-                                        value={values.email}
-                                    />
-                                </View>
+                            <View style={globalStyles.signUpForm}>
+
                                 <View style={{ marginTop: 30 }}>
                                     <Text>
                                         Your household member's first name <Text style={{ color: "red" }}> </Text>
                                     </Text>
                                     <TextInput
-                                        style={styles.InputField}
+                                        style={globalStyles.InputField}
                                         onChangeText={handleChange("firstName")}
                                         onBlur={handleBlur("firstName")}
                                         value={values.firstName}
+                                    />
+                                </View>
+
+                                <View style={{ marginTop: 30 }}>
+                                    <Text>
+                                        Your household member's email <Text style={{ color: "red" }}> {errors.email ? errors.email : ""}</Text>
+                                    </Text>
+                                    <TextInput
+                                        style={globalStyles.InputField}
+                                        onChangeText={handleChange("email")}
+                                        onBlur={handleBlur("email")}
+                                        value={values.email}
                                     />
                                     <Button onPress={handleSubmit} title="Submit" />
                                 </View>
@@ -59,7 +60,7 @@ export default function AddMember(props) {
                         )}
                     </Formik>
                 </View>
-            </ScrollView> */}
+            </ScrollView>
         </ImageBackground>
     )
 }

--- a/app/components/AddMember.js
+++ b/app/components/AddMember.js
@@ -1,0 +1,65 @@
+import React, { useEffect } from "react";
+import { Text, View, ScrollView, ImageBackground, Button, styles } from "react-native";
+import { globalStyles } from "../../styles/globalStyles";
+import { Formik } from "formik";
+
+export default function AddMember(props) {
+    return (
+        <ImageBackground source={require("../../assets/peas.jpg")} style={globalStyles.background}>
+            <View>
+                <Text style={globalStyles.button}> Invite a member to join your Household:  </Text>
+            </View>
+            {/* <ScrollView>
+                <View style={{ justifyContent: "center" }}>
+                    <Formik
+                        initialValues={{ email: "" }}
+                        validate={(values) => {
+                            const errors = {};
+                            if (!values.email) {
+                                errors.email = "Required";
+                            } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)) {
+                                errors.email = "Invalid email address";
+                            }
+                            return errors;
+                        }}
+                        //if statement to check that we dont have errors, else make thunk call
+                        onSubmit={(values) => {
+                            props.signin(values);
+                            saveUser(values);
+                            Actions.main();
+                        }}
+                    // call saveUser
+                    >
+                        {({ handleChange, handleBlur, handleSubmit, values, errors }) => (
+                            <View style={styles.signUpForm}>
+                                <View style={{ marginTop: 30 }}>
+                                    <Text>
+                                        Your household member's email <Text style={{ color: "red" }}> {errors.email ? errors.email : ""}</Text>
+                                    </Text>
+                                    <TextInput
+                                        style={styles.InputField}
+                                        onChangeText={handleChange("email")}
+                                        onBlur={handleBlur("email")}
+                                        value={values.email}
+                                    />
+                                </View>
+                                <View style={{ marginTop: 30 }}>
+                                    <Text>
+                                        Your household member's first name <Text style={{ color: "red" }}> </Text>
+                                    </Text>
+                                    <TextInput
+                                        style={styles.InputField}
+                                        onChangeText={handleChange("firstName")}
+                                        onBlur={handleBlur("firstName")}
+                                        value={values.firstName}
+                                    />
+                                    <Button onPress={handleSubmit} title="Submit" />
+                                </View>
+                            </View>
+                        )}
+                    </Formik>
+                </View>
+            </ScrollView> */}
+        </ImageBackground>
+    )
+}

--- a/app/components/HouseholdProfile.js
+++ b/app/components/HouseholdProfile.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Text, View, TouchableOpacity, Button, SafeAreaView, FlatList } from "react-native";
+import { Text, ScrollView, View, TouchableOpacity, Button, SafeAreaView, FlatList } from "react-native";
 import { globalStyles } from "../../styles/globalStyles";
 import { getAllHouseholds } from "../store/households";
 import { useDispatch, useSelector } from "react-redux";
@@ -11,7 +11,7 @@ export default function HouseholdProfile() {
         <View>
             <Text>{item.firstName} {item.lastName}</Text>
         </View>
-      );
+    );
 
     const navigate = (screen) => {
         Actions[screen]();
@@ -28,45 +28,38 @@ export default function HouseholdProfile() {
         loadAllHouseholds(user.id);
     }, [user.id]);
 
-    if(!listHouseholdId){
-        return <View><Text style={globalStyles.titleText}>You haven't joined any household!</Text></View>
+    if (!listHouseholdId) {
+        return (
+            <View>
+                <Text style={globalStyles.titleText}>You haven't joined any household!</Text>
+                <TouchableOpacity onPress={() => navigate("householdList")} title="CreateNewHousehold">
+                    <Text style={globalStyles.button}> Create New Household </Text>
+                </TouchableOpacity>
+            </View>
+        )
+
     }
     return (
-        <View>
+        <ScrollView style={globalStyles.containerScroll}>
 
-            <Text style={globalStyles.titleText}>Household Profile:</Text>
+            {/* <Text style={globalStyles.titleText}>Household Profile:</Text> */}
             {/* Reminder: right now we only have one household, and it is an object. But eventually we want many households as an array. */}
-            {/* <View>{households.map(household => {
-                            return (
-                                <View key={household.listHouseholdId}>
-                                    <Text>Household Name: {household.listHouseholdName}</Text>
-                                    <Text>Household Members: 
-                                        {
-                                            household.listHouseholdMembers.map(member => {
-                                                return (<Text>{member.firstName} {member.lastName}</Text>)
-                                            })
-                                        }</Text>
-                                    <Text>Household List: haven't linked yet</Text>
-                                </View>
-                        )
-                                    }             
-                      )
-        }</View> */}
+
 
             <View key={listHouseholdId}>
-                <Text style={globalStyles.subtitleText}>Household Name: {listHouseholdName}</Text>
+                <Text style={globalStyles.titleText}>{listHouseholdName}</Text>
                 <View>
                     <Text style={globalStyles.subtitleText}>Household Members: </Text>
 
                     {listHouseholdMembers !== undefined && listHouseholdMembers.length !== 0 ?
 
-                            <SafeAreaView>
-                                <FlatList
-                                  data={listHouseholdMembers}
-                                  renderItem={renderItem}
-                                  keyExtractor={(item, index) => index.toString()}
-                                />
-                              </SafeAreaView>
+                        <SafeAreaView>
+                            <FlatList
+                                data={listHouseholdMembers}
+                                renderItem={renderItem}
+                                keyExtractor={(item, index) => index.toString()}
+                            />
+                        </SafeAreaView>
 
                         :
                         <Text>Household member not found!</Text>
@@ -75,10 +68,17 @@ export default function HouseholdProfile() {
                 </View>
 
             </View>
+            {/* Change the navigate on next line */}
+            <TouchableOpacity onPress={() => navigate("addMember")} title="Add member">
+                <View style={{ flexDirection: 'row' }}>
+                    <Text style={globalStyles.smallButton}> + </Text>
+                    <Text> Add member to Household </Text>
+                </View>
+            </TouchableOpacity>
             <TouchableOpacity onPress={() => navigate("householdList")} title="Household List">
                 <Text style={globalStyles.button}> Household List </Text>
             </TouchableOpacity>
-        </View>
+        </ScrollView >
     )
 }
 

--- a/app/components/index.js
+++ b/app/components/index.js
@@ -6,4 +6,4 @@ export { default as ListHousehold } from "./ListHousehold"
 export { default as Dashboard } from "./Dashboard"
 export { default as Notifications } from "./Notifications"
 export { default as HouseholdProfile } from "./HouseholdProfile"
-
+export { default as AddMember } from "./AddMember"

--- a/app/screens/CreateUser.js
+++ b/app/screens/CreateUser.js
@@ -1,9 +1,11 @@
 import * as React from "react";
-import { View, Text, ScrollView, Button, StyleSheet, TextInput } from "react-native";
+import { View, Text, ScrollView, Button, TextInput } from "react-native";
 import { Formik } from "formik";
 import { createNewUser } from "../store/singleUser";
 import { connect } from "react-redux";
 import { saveUser } from "../store/storageHelper";
+import { globalStyles } from "../../styles/globalStyles";
+
 export const CreateUser = (props) => {
   return (
     <ScrollView>
@@ -41,14 +43,14 @@ export const CreateUser = (props) => {
           }}
         >
           {({ handleChange, handleBlur, handleSubmit, values, errors }) => (
-            <View style={styles.signUpForm}>
+            <View style={globalStyles.signUpForm}>
               <Text> Create an Account</Text>
               <View style={{ marginTop: 30 }}>
                 <Text>
                   Firstname <Text style={{ color: "red" }}> {errors.firstName ? errors.firstName : ""}</Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("firstName")}
                   onBlur={handleBlur("firstName")}
                   value={values.firstName}
@@ -59,7 +61,7 @@ export const CreateUser = (props) => {
                   Lastname <Text style={{ color: "red" }}> {errors.lastName ? errors.lastName : ""} </Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("lastName")}
                   onBlur={handleBlur("lastName")}
                   value={values.lastName}
@@ -70,7 +72,7 @@ export const CreateUser = (props) => {
                   Email <Text style={{ color: "red" }}> {errors.email ? errors.email : ""}</Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("email")}
                   onBlur={handleBlur("email")}
                   value={values.email}
@@ -81,7 +83,7 @@ export const CreateUser = (props) => {
                   Password <Text style={{ color: "red" }}> {errors.password ? errors.password : ""}</Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("password")}
                   onBlur={handleBlur("password")}
                   value={values.password}
@@ -95,16 +97,6 @@ export const CreateUser = (props) => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  InputField: { height: 40, borderColor: "gray", borderWidth: 1 },
-  signUpForm: {
-    flex: 1,
-    justifyContent: "center",
-    padding: 8,
-    marginTop: 15,
-  },
-});
 
 const mapDispatch = (dispatch) => ({
   register: (user) => dispatch(createNewUser(user)),

--- a/app/screens/Login.js
+++ b/app/screens/Login.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { View, Text, ScrollView, Button, StyleSheet, TextInput } from "react-native";
+import { View, Text, ScrollView, Button, TextInput } from "react-native";
 import { Formik } from "formik";
 import { login } from "../store/singleUser";
 import { connect } from "react-redux";
@@ -7,6 +7,8 @@ import { Actions } from "react-native-router-flux";
 import { useState, useEffect } from "react";
 import AsyncStorage from "@react-native-community/async-storage";
 import { saveUser } from "../store/storageHelper";
+import { globalStyles } from "../../styles/globalStyles";
+
 
 export const Login = (props) => {
   return (
@@ -36,17 +38,17 @@ export const Login = (props) => {
             saveUser(values);
             Actions.main();
           }}
-          // call saveUser
+        // call saveUser
         >
           {({ handleChange, handleBlur, handleSubmit, values, errors }) => (
-            <View style={styles.signUpForm}>
+            <View style={globalStyles.signUpForm}>
               <Text>Log in</Text>
               <View style={{ marginTop: 30 }}>
                 <Text>
                   Email <Text style={{ color: "red" }}> {errors.email ? errors.email : ""}</Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("email")}
                   onBlur={handleBlur("email")}
                   value={values.email}
@@ -57,7 +59,7 @@ export const Login = (props) => {
                   Password <Text style={{ color: "red" }}> {errors.password ? errors.password : ""}</Text>
                 </Text>
                 <TextInput
-                  style={styles.InputField}
+                  style={globalStyles.InputField}
                   onChangeText={handleChange("password")}
                   onBlur={handleBlur("password")}
                   value={values.password}
@@ -71,16 +73,6 @@ export const Login = (props) => {
     </ScrollView>
   );
 };
-
-const styles = StyleSheet.create({
-  InputField: { height: 40, borderColor: "gray", borderWidth: 1 },
-  signUpForm: {
-    flex: 1,
-    justifyContent: "center",
-    padding: 8,
-    marginTop: 15,
-  },
-});
 
 const mapDispatch = (dispatch) => ({
   signin: (user) => dispatch(login(user)),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
-    "dev": "nodemon run server & npm start",
+    "dev": "npm run server & npm start",
     "seed": "node script/seed.js",
     "start": "expo start",
     "server": "node server/index.js",

--- a/styles/globalStyles.js
+++ b/styles/globalStyles.js
@@ -111,4 +111,15 @@ export const globalStyles = StyleSheet.create({
         padding: 8,
         marginTop: 15,
     },
+    signUpForm: {
+        flex: 1,
+        justifyContent: "center",
+        padding: 8,
+        marginTop: 15,
+    },
+    InputField: {
+        height: 40,
+        borderColor: "gray",
+        borderWidth: 1
+    },
 });

--- a/styles/globalStyles.js
+++ b/styles/globalStyles.js
@@ -93,6 +93,18 @@ export const globalStyles = StyleSheet.create({
         fontSize: 25,
         marginTop: "10%",
     },
+    smallButton: {
+        backgroundColor: "#6F9A88",
+        color: "#fff",
+        width: "10%",
+        borderRadius: 25,
+        textAlign: "center",
+        fontWeight: "bold",
+        marginLeft: "10%",
+        padding: "2%",
+        fontSize: 25,
+        marginTop: "10%",
+    },
     style: {
         flex: 1,
         justifyContent: "center",


### PR DESCRIPTION
Household profile changes:
Wrapped in ScrollView (in the future, one might belong to many households)
Added a component: AddMember
For now, added a form to add your recipient’s name, and recipient’s email (and behind the scenes it should also include your household ID so that when a person with that email creates a Peasy account, they automatically get that id assigned; if the member already exists on Peasy, would just assign as well)

Cleaning Up changes:
Moved the SignUp Form style to global styles, as we use it more than once through the app